### PR TITLE
feat(#5): Medical image analysis agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,3 +90,4 @@ black src/
 - No API keys or credentials in code — use environment variables
 - Keep this file under 2500 tokens — prune session notes, keep rules
 - When an agent makes a mistake, add a rule here
+- Never gloss over or downplay failures — if tests pass but lint/format checks fail, report ALL failures clearly before moving on. Do not say "all good" when there are outstanding errors.

--- a/src/agents/image_reader.py
+++ b/src/agents/image_reader.py
@@ -1,0 +1,266 @@
+"""Medical image analysis agent.
+
+Takes uploaded medical images (wounds, rashes, X-rays), sends them to
+MedGemma 4B, and returns structured findings (description, suspected
+conditions, severity). These findings feed into the triage classifier
+via PatientData.image_findings.
+
+Usage:
+    from src.agents.image_reader import analyze, ImageFindings
+
+    findings = analyze(image_bytes, mime_type="image/jpeg")
+    print(findings.severity, findings.description)
+    summary = findings.to_triage_summary()
+"""
+
+import json
+import logging
+import re
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from src.models.medgemma import analyze_image as _model_analyze_image
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class ImageSeverity(str, Enum):
+    """Severity levels for medical image findings."""
+
+    CRITICAL = "CRITICAL"
+    SEVERE = "SEVERE"
+    MODERATE = "MODERATE"
+    MILD = "MILD"
+    NORMAL = "NORMAL"
+
+
+class ImageFindings(BaseModel):
+    """Structured output from the image analysis agent."""
+
+    modality: str = Field(
+        default="unknown", description="Image modality (X-ray, photo, etc.)"
+    )
+    description: str = Field(default="", description="Clinical description of findings")
+    suspected_conditions: list[str] = Field(
+        default_factory=list, description="Possible diagnoses"
+    )
+    severity: ImageSeverity = Field(default=ImageSeverity.MODERATE)
+    key_observations: list[str] = Field(
+        default_factory=list, description="Notable visual findings"
+    )
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    requires_specialist: bool = Field(
+        default=False, description="Whether specialist referral is recommended"
+    )
+    raw_model_response: str = Field(default="")
+    parse_failed: bool = False
+
+    def to_triage_summary(self) -> str:
+        """Format findings as a single string for PatientData.image_findings."""
+        parts: list[str] = []
+        parts.append(f"[{self.modality}] {self.description}")
+        if self.suspected_conditions:
+            parts.append(f"Suspected: {', '.join(self.suspected_conditions)}")
+        parts.append(f"Severity: {self.severity.value}")
+        if self.key_observations:
+            parts.append(f"Observations: {'; '.join(self.key_observations)}")
+        if self.requires_specialist:
+            parts.append("Specialist referral recommended")
+        return " | ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+_IMAGE_SYSTEM_PROMPT = """\
+You are a medical image analysis assistant for a Brazilian SUS emergency room. \
+You assist triage nurses — you never replace them.
+
+## Your Task
+Analyze the provided medical image and return structured findings.
+
+## Severity Levels
+
+- CRITICAL: Immediate life threat. Tension pneumothorax, \
+open fracture with vascular compromise, large hemorrhage.
+- SEVERE: Urgent, needs prompt intervention. Displaced \
+fracture, deep wound, extensive burn, significant effusion.
+- MODERATE: Notable finding needing evaluation. Simple \
+fracture, moderate wound, rash with systemic signs.
+- MILD: Minor, low urgency. Superficial wound, localized \
+rash, minor bruising, small abrasion.
+- NORMAL: No significant abnormality. Normal anatomy.
+
+## Clinical Red Flags (escalate severity)
+- Signs of infection (erythema, warmth, purulent discharge)
+- Neurovascular compromise (pallor, pulselessness, paresthesia)
+- Compartment syndrome signs
+- Open fractures or dislocations
+- Burns involving face, hands, genitalia, or circumferential
+- Signs of abuse (patterned injuries, multiple healing stages)
+
+## Conservative Bias
+When uncertain, err on the side of higher severity. It is safer to \
+over-triage than to under-triage.
+
+## Response Format
+Respond ONLY with valid JSON (no markdown, no backticks):
+{
+    "modality": "X-ray|photo|CT|MRI|ultrasound|other",
+    "description": "Brief clinical description of what the image shows",
+    "suspected_conditions": ["condition1", "condition2"],
+    "severity": "CRITICAL|SEVERE|MODERATE|MILD|NORMAL",
+    "key_observations": ["observation1", "observation2"],
+    "confidence": 0.0-1.0,
+    "requires_specialist": true/false
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_image_prompt(clinical_context: Optional[str] = None) -> str:
+    """Build the user prompt for image analysis."""
+    prompt = "Analyze this medical image and provide structured findings."
+    if clinical_context:
+        prompt += f"\n\nClinical context: {clinical_context}"
+    return prompt
+
+
+def _parse_image_response(raw: str) -> dict:
+    """Parse model response into an image findings dict using three-tier strategy.
+
+    Tier 1: Extract JSON object from response.
+    Tier 2: Regex fallback — extract severity word from text.
+    Tier 3: Default to MODERATE with parse_failed flag.
+    """
+    # Tier 1: Try to find and parse a JSON object (brace-counting for nested JSON)
+    start = raw.find("{")
+    if start != -1:
+        depth = 0
+        json_str = None
+        for i, ch in enumerate(raw[start:], start):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+            if depth == 0:
+                json_str = raw[start : i + 1]
+                break
+        if json_str:
+            try:
+                parsed = json.loads(json_str)
+                severity_str = str(parsed.get("severity", "")).upper().strip()
+                valid_severities = {s.value for s in ImageSeverity}
+                if severity_str in valid_severities:
+                    return {
+                        "modality": str(parsed.get("modality", "unknown")),
+                        "description": str(parsed.get("description", "")),
+                        "suspected_conditions": parsed.get("suspected_conditions", []),
+                        "severity": severity_str,
+                        "key_observations": parsed.get("key_observations", []),
+                        "confidence": max(
+                            0.0, min(1.0, float(parsed.get("confidence", 0.7)))
+                        ),
+                        "requires_specialist": bool(
+                            parsed.get("requires_specialist", False)
+                        ),
+                        "parse_failed": False,
+                    }
+            except (json.JSONDecodeError, ValueError, TypeError):
+                logger.warning("JSON parsing failed, trying regex fallback")
+
+    # Tier 2: Regex fallback — look for severity mention
+    severity_pattern = r"\b(CRITICAL|SEVERE|MODERATE|MILD|NORMAL)\b"
+    severity_match = re.search(severity_pattern, raw.upper())
+    if severity_match:
+        severity_str = severity_match.group(1)
+        logger.warning(
+            "Used regex fallback to extract image severity: %s", severity_str
+        )
+        return {
+            "modality": "unknown",
+            "description": raw[:500],
+            "suspected_conditions": [],
+            "severity": severity_str,
+            "key_observations": [],
+            "confidence": 0.5,
+            "requires_specialist": False,
+            "parse_failed": False,
+        }
+
+    # Tier 3: Default to MODERATE (conservative middle ground)
+    logger.error("Could not parse severity from model response")
+    return {
+        "modality": "unknown",
+        "description": raw[:500],
+        "suspected_conditions": [],
+        "severity": "MODERATE",
+        "key_observations": [],
+        "confidence": 0.3,
+        "requires_specialist": False,
+        "parse_failed": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def analyze(
+    image_bytes: bytes,
+    mime_type: str = "image/jpeg",
+    clinical_context: str | None = None,
+) -> ImageFindings:
+    """Analyze a medical image and return structured findings.
+
+    Args:
+        image_bytes: Raw image bytes (JPEG, PNG, etc.).
+        mime_type: MIME type of the image.
+        clinical_context: Optional patient context to guide analysis.
+
+    Returns:
+        ImageFindings with severity, description, and observations.
+
+    Raises:
+        openai.APIError: If the model call fails (not caught here).
+        EnvironmentError: If model configuration is missing.
+    """
+    user_prompt = _build_image_prompt(clinical_context)
+
+    logger.info("Calling MedGemma 4B for image analysis")
+    raw_response = _model_analyze_image(
+        image=image_bytes,
+        prompt=user_prompt,
+        system_prompt=_IMAGE_SYSTEM_PROMPT,
+        mime_type=mime_type,
+        max_tokens=1024,
+        temperature=0.1,
+    )
+    logger.info("Model response received (%d chars)", len(raw_response))
+
+    parsed = _parse_image_response(raw_response)
+
+    return ImageFindings(
+        modality=parsed["modality"],
+        description=parsed["description"],
+        suspected_conditions=parsed["suspected_conditions"],
+        severity=ImageSeverity(parsed["severity"]),
+        key_observations=parsed["key_observations"],
+        confidence=parsed["confidence"],
+        requires_specialist=parsed["requires_specialist"],
+        raw_model_response=raw_response,
+        parse_failed=parsed["parse_failed"],
+    )

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -18,12 +18,10 @@ from src.agents.triage import (
 )
 
 # --- SWAP POINT: change these imports to use real agents -----------------
+from src.agents.image_reader import analyze as analyze_image_agent
 from src.ui.mock_services import (
     SAMPLE_CASES,
     build_mock_fhir_bundle,
-)
-from src.ui.mock_services import (
-    mock_analyze_image as analyze_image,
 )
 from src.ui.mock_services import (
     mock_classify as classify_patient,
@@ -31,7 +29,6 @@ from src.ui.mock_services import (
 
 # When real agents are ready, uncomment below and remove mock imports:
 # from src.agents.triage import classify as classify_patient
-# from src.models.medgemma import analyze_image
 # from src.fhir.builder import build_fhir_bundle as build_mock_fhir_bundle
 # -------------------------------------------------------------------------
 
@@ -297,9 +294,13 @@ def _render_image_upload() -> None:
         st.image(uploaded, caption=uploaded.name, use_container_width=True)
         image_bytes = uploaded.getvalue()
         mime_type = uploaded.type or "image/jpeg"
-        findings = analyze_image(image_bytes, mime_type)
-        st.session_state["image_findings"] = findings
-        st.info(f"**Achados da imagem:** {findings}")
+        findings = analyze_image_agent(image_bytes, mime_type)
+        st.session_state["image_findings"] = findings.to_triage_summary()
+        severity_display = findings.severity.value
+        st.info(
+            f"**Severidade:** {severity_display}\n\n"
+            f"**Achados:** {findings.description}"
+        )
     else:
         st.session_state["image_findings"] = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,8 +63,52 @@ _DEFAULT_TEXT_RESPONSE = (
     "is warranted."
 )
 
-_DEFAULT_IMAGE_RESPONSE = (
-    "The image shows no acute abnormalities. Recommend clinical correlation."
+_IMAGE_RESPONSES: dict[str, str] = {
+    "wound": json.dumps(
+        {
+            "modality": "photo",
+            "description": "Deep laceration on forearm with active bleeding",
+            "suspected_conditions": ["laceration", "tendon injury"],
+            "severity": "SEVERE",
+            "key_observations": ["exposed tissue", "active bleeding"],
+            "confidence": 0.85,
+            "requires_specialist": True,
+        }
+    ),
+    "rash": json.dumps(
+        {
+            "modality": "photo",
+            "description": "Erythematous maculopapular rash on trunk",
+            "suspected_conditions": ["allergic reaction", "viral exanthem"],
+            "severity": "MODERATE",
+            "key_observations": ["widespread distribution", "no vesicles"],
+            "confidence": 0.7,
+            "requires_specialist": False,
+        }
+    ),
+    "fracture": json.dumps(
+        {
+            "modality": "X-ray",
+            "description": "Displaced fracture of the distal radius",
+            "suspected_conditions": ["Colles fracture"],
+            "severity": "SEVERE",
+            "key_observations": ["cortical disruption", "dorsal angulation"],
+            "confidence": 0.9,
+            "requires_specialist": True,
+        }
+    ),
+}
+
+_DEFAULT_IMAGE_RESPONSE = json.dumps(
+    {
+        "modality": "unknown",
+        "description": "No acute abnormalities identified",
+        "suspected_conditions": [],
+        "severity": "NORMAL",
+        "key_observations": [],
+        "confidence": 0.7,
+        "requires_specialist": False,
+    }
 )
 
 
@@ -77,8 +121,16 @@ def _mock_generate_text(prompt: str, **kwargs: object) -> str:
     return _DEFAULT_TEXT_RESPONSE
 
 
-def _mock_analyze_image(**kwargs: object) -> str:
-    """Return a static image analysis response."""
+def _mock_analyze_image(
+    image: bytes = b"",
+    prompt: str = "",
+    **kwargs: object,
+) -> str:
+    """Return a keyword-matched JSON image analysis response."""
+    prompt_lower = prompt.lower()
+    for keyword, response in _IMAGE_RESPONSES.items():
+        if keyword in prompt_lower:
+            return response
     return _DEFAULT_IMAGE_RESPONSE
 
 

--- a/tests/test_agents/test_image_reader.py
+++ b/tests/test_agents/test_image_reader.py
@@ -1,0 +1,337 @@
+"""Tests for the medical image analysis agent."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.image_reader import (
+    ImageFindings,
+    ImageSeverity,
+    _build_image_prompt,
+    _parse_image_response,
+    analyze,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def valid_json_response() -> str:
+    return json.dumps(
+        {
+            "modality": "X-ray",
+            "description": "Chest X-ray showing bilateral infiltrates",
+            "suspected_conditions": ["pneumonia", "pulmonary edema"],
+            "severity": "SEVERE",
+            "key_observations": [
+                "bilateral opacities",
+                "air bronchograms",
+            ],
+            "confidence": 0.85,
+            "requires_specialist": True,
+        }
+    )
+
+
+@pytest.fixture
+def sample_image_bytes() -> bytes:
+    """Minimal valid JPEG header for testing (not a real image)."""
+    return b"\xff\xd8\xff\xe0" + b"\x00" * 100
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: data models
+# ---------------------------------------------------------------------------
+
+
+class TestImageSeverity:
+    def test_all_levels(self) -> None:
+        assert len(ImageSeverity) == 5
+        for level in ["CRITICAL", "SEVERE", "MODERATE", "MILD", "NORMAL"]:
+            assert ImageSeverity(level).value == level
+
+
+class TestImageFindings:
+    def test_minimal_construction(self) -> None:
+        findings = ImageFindings(
+            severity=ImageSeverity.MODERATE,
+            raw_model_response="test",
+        )
+        assert findings.severity == ImageSeverity.MODERATE
+        assert findings.modality == "unknown"
+        assert findings.description == ""
+        assert findings.suspected_conditions == []
+        assert findings.key_observations == []
+        assert findings.requires_specialist is False
+
+    def test_full_construction(self) -> None:
+        findings = ImageFindings(
+            modality="X-ray",
+            description="Fracture of the distal radius",
+            suspected_conditions=["Colles fracture"],
+            severity=ImageSeverity.SEVERE,
+            key_observations=["cortical disruption", "dorsal angulation"],
+            confidence=0.9,
+            requires_specialist=True,
+            raw_model_response="raw",
+            parse_failed=False,
+        )
+        assert findings.modality == "X-ray"
+        assert findings.confidence == 0.9
+        assert findings.requires_specialist is True
+        assert len(findings.key_observations) == 2
+
+    def test_to_triage_summary_full(self) -> None:
+        findings = ImageFindings(
+            modality="photo",
+            description="Deep laceration on forearm",
+            suspected_conditions=["laceration", "tendon injury"],
+            severity=ImageSeverity.SEVERE,
+            key_observations=["exposed tissue", "active bleeding"],
+            confidence=0.8,
+            requires_specialist=True,
+            raw_model_response="raw",
+        )
+        summary = findings.to_triage_summary()
+        assert "[photo]" in summary
+        assert "Deep laceration" in summary
+        assert "laceration" in summary
+        assert "Severity: SEVERE" in summary
+        assert "exposed tissue" in summary
+        assert "Specialist referral recommended" in summary
+
+    def test_to_triage_summary_minimal(self) -> None:
+        findings = ImageFindings(
+            modality="unknown",
+            description="No findings",
+            severity=ImageSeverity.NORMAL,
+            raw_model_response="raw",
+        )
+        summary = findings.to_triage_summary()
+        assert "Severity: NORMAL" in summary
+        assert "Specialist" not in summary
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: prompt construction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildImagePrompt:
+    def test_without_context(self) -> None:
+        prompt = _build_image_prompt()
+        assert "Analyze" in prompt
+        assert "Clinical context" not in prompt
+
+    def test_with_context(self) -> None:
+        prompt = _build_image_prompt("Patient reports fall from height")
+        assert "Clinical context" in prompt
+        assert "fall from height" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: response parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseImageResponse:
+    def test_valid_json(self, valid_json_response: str) -> None:
+        result = _parse_image_response(valid_json_response)
+        assert result["severity"] == "SEVERE"
+        assert result["modality"] == "X-ray"
+        assert result["confidence"] == 0.85
+        assert result["requires_specialist"] is True
+        assert len(result["suspected_conditions"]) == 2
+        assert result["parse_failed"] is False
+
+    def test_json_with_markdown_fences(self) -> None:
+        inner = json.dumps(
+            {
+                "modality": "photo",
+                "description": "Wound on left arm",
+                "suspected_conditions": ["laceration"],
+                "severity": "MODERATE",
+                "key_observations": ["clean edges"],
+                "confidence": 0.75,
+                "requires_specialist": False,
+            }
+        )
+        raw = f"```json\n{inner}\n```"
+        result = _parse_image_response(raw)
+        assert result["severity"] == "MODERATE"
+        assert result["parse_failed"] is False
+
+    def test_json_with_surrounding_text(self) -> None:
+        inner = json.dumps(
+            {
+                "modality": "X-ray",
+                "description": "Normal chest",
+                "suspected_conditions": [],
+                "severity": "NORMAL",
+                "key_observations": [],
+                "confidence": 0.9,
+                "requires_specialist": False,
+            }
+        )
+        raw = f"Here is my analysis:\n{inner}\nEnd of analysis."
+        result = _parse_image_response(raw)
+        assert result["severity"] == "NORMAL"
+        assert result["parse_failed"] is False
+
+    def test_regex_fallback(self) -> None:
+        raw = "The image shows a SEVERE wound requiring immediate attention."
+        result = _parse_image_response(raw)
+        assert result["severity"] == "SEVERE"
+        assert result["confidence"] == 0.5
+        assert result["parse_failed"] is False
+        assert result["modality"] == "unknown"
+
+    def test_regex_fallback_lowercase(self) -> None:
+        raw = "This appears to be a mild bruise with no complications."
+        result = _parse_image_response(raw)
+        assert result["severity"] == "MILD"
+
+    def test_parse_failure_defaults_moderate(self) -> None:
+        raw = "Unable to analyze the provided image."
+        result = _parse_image_response(raw)
+        assert result["severity"] == "MODERATE"
+        assert result["parse_failed"] is True
+        assert result["confidence"] == 0.3
+
+    def test_invalid_severity_in_json(self) -> None:
+        raw = json.dumps({"severity": "EXTREME", "description": "test"})
+        result = _parse_image_response(raw)
+        # "EXTREME" not valid, falls through to tier 3
+        assert result["parse_failed"] is True
+
+    def test_confidence_clamped_above_one(self) -> None:
+        raw = json.dumps(
+            {
+                "modality": "photo",
+                "description": "Test",
+                "severity": "MILD",
+                "confidence": 1.5,
+            }
+        )
+        result = _parse_image_response(raw)
+        assert result["confidence"] == 1.0
+
+    def test_confidence_clamped_below_zero(self) -> None:
+        raw = json.dumps(
+            {
+                "modality": "photo",
+                "description": "Test",
+                "severity": "MILD",
+                "confidence": -0.3,
+            }
+        )
+        result = _parse_image_response(raw)
+        assert result["confidence"] == 0.0
+
+    def test_missing_confidence_uses_default(self) -> None:
+        raw = json.dumps(
+            {
+                "modality": "photo",
+                "description": "Test",
+                "severity": "NORMAL",
+            }
+        )
+        result = _parse_image_response(raw)
+        assert result["confidence"] == 0.7
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: analyze (mocked model)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyze:
+    @patch("src.agents.image_reader._model_analyze_image")
+    def test_valid_analysis(
+        self,
+        mock_model: object,
+        sample_image_bytes: bytes,
+        valid_json_response: str,
+    ) -> None:
+        mock_model.return_value = valid_json_response  # type: ignore[attr-defined]
+
+        result = analyze(sample_image_bytes)
+
+        assert isinstance(result, ImageFindings)
+        assert result.severity == ImageSeverity.SEVERE
+        assert result.modality == "X-ray"
+        assert result.parse_failed is False
+        assert result.raw_model_response == valid_json_response
+
+    @patch("src.agents.image_reader._model_analyze_image")
+    def test_with_clinical_context(
+        self,
+        mock_model: object,
+        sample_image_bytes: bytes,
+        valid_json_response: str,
+    ) -> None:
+        mock_model.return_value = valid_json_response  # type: ignore[attr-defined]
+
+        analyze(sample_image_bytes, clinical_context="Patient fell from ladder")
+
+        call_kwargs = mock_model.call_args  # type: ignore[attr-defined]
+        assert "fell from ladder" in call_kwargs.kwargs["prompt"]
+
+    @patch("src.agents.image_reader._model_analyze_image")
+    def test_without_clinical_context(
+        self,
+        mock_model: object,
+        sample_image_bytes: bytes,
+        valid_json_response: str,
+    ) -> None:
+        mock_model.return_value = valid_json_response  # type: ignore[attr-defined]
+
+        analyze(sample_image_bytes)
+
+        call_kwargs = mock_model.call_args  # type: ignore[attr-defined]
+        assert "Clinical context" not in call_kwargs.kwargs["prompt"]
+
+    @patch("src.agents.image_reader._model_analyze_image")
+    def test_model_call_parameters(
+        self,
+        mock_model: object,
+        sample_image_bytes: bytes,
+        valid_json_response: str,
+    ) -> None:
+        mock_model.return_value = valid_json_response  # type: ignore[attr-defined]
+
+        analyze(sample_image_bytes, mime_type="image/png")
+
+        mock_model.assert_called_once()  # type: ignore[attr-defined]
+        call_kwargs = mock_model.call_args  # type: ignore[attr-defined]
+        assert call_kwargs.kwargs["max_tokens"] == 1024
+        assert call_kwargs.kwargs["temperature"] == 0.1
+        assert call_kwargs.kwargs["mime_type"] == "image/png"
+        assert call_kwargs.kwargs["image"] == sample_image_bytes
+
+    @patch("src.agents.image_reader._model_analyze_image")
+    def test_api_error_propagates(
+        self,
+        mock_model: object,
+        sample_image_bytes: bytes,
+    ) -> None:
+        mock_model.side_effect = RuntimeError("API connection failed")  # type: ignore[attr-defined]
+
+        with pytest.raises(RuntimeError, match="API connection failed"):
+            analyze(sample_image_bytes)
+
+    @patch("src.agents.image_reader._model_analyze_image")
+    def test_parse_failure_returns_moderate(
+        self,
+        mock_model: object,
+        sample_image_bytes: bytes,
+    ) -> None:
+        mock_model.return_value = "Unable to process."  # type: ignore[attr-defined]
+
+        result = analyze(sample_image_bytes)
+
+        assert result.severity == ImageSeverity.MODERATE
+        assert result.parse_failed is True


### PR DESCRIPTION
## Summary
- Add `src/agents/image_reader.py` — analyzes medical images via MedGemma 4B, returns structured `ImageFindings` (severity, description, suspected conditions, key observations)
- 3-tier response parser (JSON → regex fallback → conservative MODERATE default)
- Wire real agent into Streamlit UI, replacing `mock_analyze_image`
- Update `conftest.py` mock to return JSON matching `ImageFindings` schema

Closes #5

## Test plan
- [x] `pytest tests/test_agents/test_image_reader.py -v` — 23 tests pass
- [x] `ruff check src/agents/image_reader.py` — clean
- [x] `black --check src/agents/image_reader.py` — clean
- [x] `pytest tests/ -v` — full suite (92 tests) passes
- [ ] Manual: `streamlit run src/ui/app.py` — upload a test image, verify findings appear